### PR TITLE
add "result-encoding: string" to actions/github-script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,7 @@ jobs:
         id: repo_info
         uses: actions/github-script@v7
         with:
+          result-encoding: string
           script: |
             const repoInfo = await github.rest.repos.get({
               owner: context.repo.owner,


### PR DESCRIPTION
this should fix the issue we have with extraneous quotes in resulting docker labels:

```
"org.opencontainers.image.licenses": "\"Apache-2.0\"",
```