### PR TITLE
go 1.24.1 -> 1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module registryproxy
 
-go 1.24.0
-
-toolchain go1.24.1
+go 1.25
 
 require (
 	aidanwoods.dev/go-paseto v1.6.0


### PR DESCRIPTION
update go version to address CVE-2025-22871